### PR TITLE
Include .tsx files in search

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -42,7 +42,7 @@ function handlePaths(files, excludePatterns, globOptions) {
 
 				searchedParents.add(file);
 
-				let pattern = path.join(file, '**', '*.ts');
+				let pattern = path.join(file, '**', '*.{ts,tsx}');
 
 				if (process.platform === 'win32') {
 					// Always use `/` in patterns, harmonizing matching across platforms
@@ -57,7 +57,7 @@ function handlePaths(files, excludePatterns, globOptions) {
 			return path.normalize(file);
 		})
 		.then(flatten)
-		.filter(file => file && path.extname(file) === '.ts')
+		.filter(file => file && (path.extname(file) === '.ts' || path.extname(file) === '.tsx'))
 		.filter(file => {
 			if (path.basename(file)[0] === '_' && globOptions.includeUnderscoredFiles !== true) {
 				return false;
@@ -81,11 +81,14 @@ const defaultExcludePatterns = () => [
 ];
 
 const defaultIncludePatterns = () => [
-	'test.ts',
-	'test-*.ts',
+  'test.ts',
+  'test.tsx',
+  'test-*.ts',
+  'test-*.tsx',
 	'test',
 	'**/__tests__',
-	'**/*.test.ts'
+  '**/*.test.ts',
+  '**/*.test.tsx'
 ];
 
 const defaultHelperPatterns = () => [
@@ -171,7 +174,7 @@ class AvaFiles {
 
 		// Same defaults as used for Chokidar
 		if (!hasPositivePattern) {
-			mixedPatterns = ['package.json', '**/*.ts'].concat(mixedPatterns);
+			mixedPatterns = ['package.json', '**/*.{ts,tsx}'].concat(mixedPatterns);
 		}
 
 		filePath = matchable(filePath);
@@ -205,7 +208,7 @@ class AvaFiles {
 		const initialPatterns = this.files.concat(excludePatterns);
 
 		// Like in `api.ts`, tests must be `.ts` files and not start with `_`
-		if (path.extname(filePath) !== '.ts' || path.basename(filePath)[0] === '_') {
+		if ((path.extname(filePath) !== '.ts' && path.extname(filePath) !== '.tsx') || path.basename(filePath)[0] === '_') {
 			return false;
 		}
 
@@ -240,7 +243,7 @@ class AvaFiles {
 		const recursivePatterns = subpaths
 			.filter(subpath => multimatch(subpath, initialPatterns).length === 1)
 			// Always use `/` to makes multimatch consistent across platforms
-			.map(subpath => `${subpath}/**/*.ts`);
+			.map(subpath => `${subpath}/**/*.{ts,tsx}`);
 
 		// See if the entire path matches any of the subpaths patterns, taking the
 		// excludePatterns into account. This mimicks the behavior in api.ts
@@ -271,7 +274,7 @@ class AvaFiles {
 		ignored = getDefaultIgnorePatterns().concat(ignored, overrideDefaultIgnorePatterns);
 
 		if (paths.length === 0) {
-			paths = ['package.json', '**/*.ts', '**/*.snap'];
+			paths = ['package.json', '**/*.ts', '**/*.tsx', '**/*.snap'];
 		}
 
 		paths = paths.concat(this.files);

--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -81,14 +81,14 @@ const defaultExcludePatterns = () => [
 ];
 
 const defaultIncludePatterns = () => [
-  'test.ts',
-  'test.tsx',
-  'test-*.ts',
-  'test-*.tsx',
+	'test.ts',
+	'test.tsx',
+	'test-*.ts',
+	'test-*.tsx',
 	'test',
 	'**/__tests__',
-  '**/*.test.ts',
-  '**/*.test.tsx'
+	'**/*.test.ts',
+	'**/*.test.tsx'
 ];
 
 const defaultHelperPatterns = () => [

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,7 +53,7 @@ exports.run = () => {
 		  ava-ts --init foo.ts
 
 		Default patterns when no arguments:
-		test.ts test-*.ts test/**/*.ts **/__tests__/**/*.ts **/*.test.ts
+		test.ts test.tsx test-*.ts test-*.tsx test/**/*.ts test/**/*.tsx **/__tests__/**/*.ts **/__tests__/**/*.tsx **/*.test.ts **/*.test.tsx
 	`, {
 		string: [
 			'_',

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ $ ava-ts --help
     ava-ts --init foo.ts
 
   Default patterns when no arguments:
-  test.ts test-*.ts test/**/*.ts **/__tests__/**/*.ts **/*.test.ts
+  test.ts test.tsx test-*.ts test-*.tsx test/**/*.ts test/**/*.tsx **/__tests__/**/*.ts **/__tests__/**/*.tsx **/*.test.ts **/*.test.tsx
 ```
 
 ## Documentation

--- a/test/sample.tsx
+++ b/test/sample.tsx
@@ -1,0 +1,22 @@
+import test from 'ava'
+import * as React from 'react'
+import * as ShallowRenderer from 'react-test-renderer/shallow'
+
+function MyComponent() {
+  return (
+    <div>
+      <span className="heading">Title</span>
+    </div>
+  );
+}
+
+test('can use jsx when testing', t => {
+	const renderer = new ShallowRenderer();
+	renderer.render(<MyComponent />);
+	const result = renderer.getRenderOutput();
+
+	t.is(result.type, 'div');
+	t.deepEqual(result.props.children,
+		<span className="heading">Title</span>
+	);
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"jsx": "react"
+	}
+}


### PR DESCRIPTION
Fixes #4
I think this important as I could find no other way to use Enzyme to test react components. Typescript does not allow you to include jsx in .ts files.
