### PR TITLE
Update beautify-stack.js to include ava-ts and ava-ts dependencies in…

### DIFF
--- a/lib/beautify-stack.js
+++ b/lib/beautify-stack.js
@@ -7,13 +7,17 @@ const debug = require('debug')('ava');
 let ignoreStackLines = [];
 
 const avaInternals = /\/ava\/(?:lib\/)?[\w-]+\.js:\d+:\d+\)?$/;
+const avaTsInternals = /\/ava-ts\/(?:lib\/)?[\w-]+\.js:\d+:\d+\)?$/;
 const avaDependencies = /\/node_modules\/(?:bluebird|empower-core|(?:ava\/node_modules\/)?(?:babel-runtime|core-js))\//;
+const avaTsDependencies = /\/node_modules\/source-map-support\//
 const stackFrameLine = /^.+( \(.+:\d+:\d+\)|:\d+:\d+)$/;
 
 if (!debug.enabled) {
 	ignoreStackLines = StackUtils.nodeInternals();
 	ignoreStackLines.push(avaInternals);
 	ignoreStackLines.push(avaDependencies);
+	ignoreStackLines.push(avaTsInternals);
+	ignoreStackLines.push(avaTsDependencies);
 }
 
 const stackUtils = new StackUtils({internals: ignoreStackLines});


### PR DESCRIPTION
I was unsure if you would prefer to update the regex for `avaInternals` and `avaDependencies` or to have them in their own variables. For instance just adding `(-ts)?` after `\/ava` cleaned up most of the stack. `source-map-support` also needed to be added to dependencies but was also not much of an obstruction.

Either way it works like a charm!

If you know of any other dependencies that might need to be ignored, I will certainly add them. This was enough for my simple test case. 